### PR TITLE
feat: Add author profile component below blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import { CustomMDX } from 'app/components/mdx'
 import { formatDate, getBlogPosts } from 'app/blog/utils'
 import { baseUrl } from 'app/sitemap'
+import AuthorProfile from 'app/components/AuthorProfile'
 
 export async function generateStaticParams() {
   let posts = getBlogPosts()
@@ -95,6 +96,13 @@ export default async function Blog({ params }: { params: Promise<{ slug: string 
       <article className="prose">
         <CustomMDX source={post.content} />
       </article>
+      <AuthorProfile
+        author={{
+          name: "John Doe",
+          bio: "A passionate writer and developer.",
+          avatarUrl: "/images/avatar.png",
+        }}
+      />
     </section>
   )
 }

--- a/app/components/AuthorProfile.tsx
+++ b/app/components/AuthorProfile.tsx
@@ -1,0 +1,23 @@
+type AuthorProfileProps = {
+  author: {
+    name: string;
+    bio: string;
+    avatarUrl: string;
+  };
+};
+
+export default function AuthorProfile({ author }: AuthorProfileProps) {
+  return (
+    <div className="flex items-center gap-4 p-6 rounded-2xl border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800">
+      <img
+        src={author.avatarUrl}
+        alt={author.name}
+        className="w-16 h-16 rounded-full object-cover shrink-0"
+      />
+      <div>
+        <p className="font-bold text-neutral-900 dark:text-neutral-100">{author.name}</p>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">{author.bio}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 변경사항

### 주요 변경사항

- [x] UI/UX 개선

### 상세 설명

게시글 하단에 작가 정보를 표시하는 `AuthorProfile` 컴포넌트를 추가한다.
`AuthorProfile`은 `name`, `bio`, `avatarUrl`을 prop으로 받아 아바타 이미지,
이름, 소개글을 Tailwind CSS로 렌더링하며, 다크 모드를 지원한다.
`blog/[slug]/page.tsx`에서 게시물 본문 하단에 컴포넌트를 통합하였다.

## 🔍 변경된 파일

- `app/components/AuthorProfile.tsx` - 작가 프로필 컴포넌트 신규 추가
- `app/blog/[slug]/page.tsx` - 게시물 상세 페이지에 AuthorProfile 컴포넌트 통합

## 🧪 테스트

- [ ] 로컬에서 개발 서버 실행 확인
- [ ] 블로그 포스트 렌더링 확인
- [ ] 반응형 디자인 확인
- [ ] SEO 메타데이터 확인

### 테스트 방법

```bash
# 개발 서버 실행
pnpm dev

# 빌드 테스트
pnpm build

# 린트 검사
pnpm lint
```

## ✅ 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체적으로 코드를 검토했습니다
- [ ] 코드에 대한 주석을 작성했습니다 (특히 이해하기 어려운 부분)
- [ ] 해당 변경사항에 대한 문서를 업데이트했습니다
- [ ] 새로운 기능에 대한 테스트를 추가했습니다
- [ ] 모든 테스트가 통과합니다

## 🚀 배포 관련

- [x] 이 변경사항이 프로덕션에 배포되어도 안전합니다
- [x] 환경 변수 변경이 필요한 경우 문서화했습니다

## 📚 관련 이슈

Closes #2

---

**리뷰어 참고사항:**

- 현재 작가 데이터는 임시 하드코딩 상태이며, 추후 실제 데이터 연동 필요
- 아바타 이미지 경로(`/images/avatar.png`)는 실제 이미지 추가 후 교체 필요